### PR TITLE
Add simplified test source collection script

### DIFF
--- a/collect_test_sources.sh
+++ b/collect_test_sources.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-set -eu
+set -eu # fail on non-zero retcode or undefined variable
 print_usage() {
   printf "usage: $(basename $0) [-x] [-e] [-f] [-t] [-h]\n\n"
   printf "print rustc UI test sources which satisfy certain criteria; by default those that are:\n"
@@ -45,6 +44,7 @@ while getopts 'xfet' opt; do
 done
 
 # check test dir
+# NOTE: ${var:-default} expands to default if var unset
 [ -z "${RUST_TOP:-}" ] && print_usage "set RUST_TOP environment variable to your local Rust compiler source directory before running this script"
 RUST_TESTS=${RUST_TOP}/tests
 [ ! -d "${RUST_TESTS}" ] && print_usage "RUST_TOP environment variable does not appear to point to a local Rust compiler source directory"

--- a/collect_test_sources.sh
+++ b/collect_test_sources.sh
@@ -47,14 +47,14 @@ RUST_TESTS=${RUST_TOP}/tests
 [ ! -d "${RUST_TESTS}" ] && print_usage "RUST_TOP environment variable does not appear to point to a local Rust compiler source directory"
 
 # find test source files that pass filters
-find "${RUST_TESTS}/ui"
-     -name '*.rs'    \
-     "${RUSTFIX[@]}" \
-     "${RUNPASS[@]}" \
-     "${HASMAIN[@]}" \
-     "${EMPMAIN[@]}" \
-     "${TIMEMIR[@]}" \
-     -print          \
+find "${RUST_TESTS}/ui" \
+     -name '*.rs'       \
+     "${RUSTFIX[@]}"    \
+     "${RUNPASS[@]}"    \
+     "${HASMAIN[@]}"    \
+     "${EMPMAIN[@]}"    \
+     "${TIMEMIR[@]}"    \
+     -print             \
   | sort
 
 # remove temp mir file whenever timing mir, ignore errors

--- a/collect_test_sources.sh
+++ b/collect_test_sources.sh
@@ -3,7 +3,7 @@
 set -e
 print_usage() {
   printf "usage: $(basename $0) [-x] [-e] [-f] [-t] [-h]\n\n"
-  printf "print out rustc UI tests which satisfy certain criteria; by default those that are:\n"
+  printf "print rustc UI test sources which satisfy certain criteria; by default those that are:\n"
   printf "normal, passing, contain a non-empty main function, and compile in reasonable time\n\n"
   printf "options:\n"
   printf "x\tinclude fixed tests [may contain run-rustfix header]\n"
@@ -46,7 +46,7 @@ done
 RUST_TESTS=${RUST_TOP}/tests
 [ ! -d "${RUST_TESTS}" ] && print_usage "RUST_TOP environment variable does not appear to point to a local Rust compiler source directory"
 
-# find test files that pass filters
+# find test source files that pass filters
 find "${RUST_TESTS}/ui"
      -name '*.rs'    \
      "${RUSTFIX[@]}" \

--- a/collect_test_sources.sh
+++ b/collect_test_sources.sh
@@ -10,7 +10,8 @@ print_usage() {
   printf "f\tinclude failing tests [may NOT contain run-pass header] (implies -t)\n"
   printf "t\tinclude tests that fail to generate MIR within 30s\n"
   printf "h\tprint this usage and exit\n\n"
-  echo "$@"
+  printf "if -t unset, set environment variable RUSTC_MIR_VERBOSE to see raw rustc invocation and CLI output\n\n"
+  [ $# -ne 0 ] && echo "ERROR: $*"
   exit 1
 }
 

--- a/collect_test_sources.sh
+++ b/collect_test_sources.sh
@@ -50,14 +50,15 @@ RUST_TESTS=${RUST_TOP}/tests
 [ ! -d "${RUST_TESTS}" ] && print_usage "RUST_TOP environment variable does not appear to point to a local Rust compiler source directory"
 
 # find test source files that pass filters
-find "${RUST_TESTS}/ui" \
-     -name '*.rs'       \
-     "${RUSTFIX[@]}"    \
-     "${RUNPASS[@]}"    \
-     "${HASMAIN[@]}"    \
-     "${EMPMAIN[@]}"    \
-     "${TIMEMIR[@]}"    \
-     -print
+( cd "${RUST_TOP}";
+  find tests/ui           \
+       -name '*.rs'       \
+       "${RUSTFIX[@]}"    \
+       "${RUNPASS[@]}"    \
+       "${HASMAIN[@]}"    \
+       "${EMPMAIN[@]}"    \
+       "${TIMEMIR[@]}"    \
+       -print )
 
 # remove temp mir file whenever timing mir, ignore errors
 if [ -n "${TIMEMIR[*]}" ]; then

--- a/collect_test_sources.sh
+++ b/collect_test_sources.sh
@@ -10,7 +10,9 @@ print_usage() {
   printf "f\tinclude failing tests [may NOT contain run-pass header] (implies -t)\n"
   printf "t\tinclude tests that fail to generate MIR within 30s\n"
   printf "h\tprint this usage and exit\n\n"
-  printf "if -t unset, set environment variable RUSTC_MIR_VERBOSE to see raw rustc invocation and CLI output\n\n"
+  printf "if -t unset:\n"
+  printf "  set environment variable RUSTC_MIR_VERBOSE to see raw rustc invocation and CLI output\n"
+  printf "  set environment variable RUSTC_MIR_NOFILEOPTS to skip //@ compile-flags: ...\n\n"
   [ $# -ne 0 ] && echo "ERROR: $*"
   exit 1
 }

--- a/collect_test_sources.sh
+++ b/collect_test_sources.sh
@@ -61,5 +61,5 @@ find "${RUST_TESTS}/ui" \
 
 # remove temp mir file whenever timing mir, ignore errors
 if [ -n "${TIMEMIR[*]}" ]; then
-  rm "$TMPMIR" &> /dev/null
+  rm "$TMPMIR" &> /dev/null || true
 fi

--- a/collect_test_sources.sh
+++ b/collect_test_sources.sh
@@ -26,10 +26,11 @@ RUSTOPT=('-C' 'overflow-checks=off')
 TIMEMIR=('-execdir' 'timeout' '30s' "$RUSTC_MIR" '{}' "$TMPMIR" "${RUSTOPT[@]}" ';')
 
 # setup grep filters
-RUSTFIX=('-execdir' 'grep' '-qv' '//@[[:space:]]*run-rustfix'                                  '{}' ';')
-RUNPASS=('-execdir' 'grep' '-q'  '//@[[:space:]]*run-pass'                                     '{}' ';')
-HASMAIN=('-execdir' 'grep' '-q'  'fn main[[:space:]]*([[:space:]]*)'                           '{}' ';')
-EMPMAIN=('-execdir' 'grep' '-qv' 'fn main[[:space:]]*([[:space:]]*)[[:space:]]*{[[:space:]]*}' '{}' ';')
+HAS_MATCH=$SCRIPT_DIR/has_match.sh
+RUSTFIX=('-execdir' "$HAS_MATCH" 'n' '//@[[:space:]]*run-rustfix'                                  '{}' ';')
+RUNPASS=('-execdir' "$HAS_MATCH" 'y' '//@[[:space:]]*run-pass'                                     '{}' ';')
+HASMAIN=('-execdir' "$HAS_MATCH" 'y' 'fn main[[:space:]]*([[:space:]]*)'                           '{}' ';')
+EMPMAIN=('-execdir' "$HAS_MATCH" 'n' 'fn main[[:space:]]*([[:space:]]*)[[:space:]]*{[[:space:]]*}' '{}' ';')
 
 # parse opts
 while getopts 'xfet' opt; do

--- a/collect_test_sources.sh
+++ b/collect_test_sources.sh
@@ -50,6 +50,11 @@ done
 RUST_TESTS=${RUST_TOP}/tests
 [ ! -d "${RUST_TESTS}" ] && print_usage "RUST_TOP environment variable does not appear to point to a local Rust compiler source directory"
 
+# clean temp mir file whenever timing mir, ignore errors
+if [ -n "${TIMEMIR[*]}" ]; then
+  trap "rm \"$TMPMIR\" &> /dev/null" SIGINT SIGTERM EXIT
+fi
+
 # find test source files that pass filters
 ( cd "${RUST_TOP}";
   find tests/ui           \
@@ -60,8 +65,3 @@ RUST_TESTS=${RUST_TOP}/tests
        "${EMPMAIN[@]}"    \
        "${TIMEMIR[@]}"    \
        -print )
-
-# remove temp mir file whenever timing mir, ignore errors
-if [ -n "${TIMEMIR[*]}" ]; then
-  rm "$TMPMIR" &> /dev/null || true
-fi

--- a/collect_test_sources.sh
+++ b/collect_test_sources.sh
@@ -27,10 +27,10 @@ TIMEMIR=('-execdir' 'timeout' '30s' "$RUSTC_MIR" '{}' "$TMPMIR" "${RUSTOPT[@]}" 
 
 # setup grep filters
 HAS_MATCH=$SCRIPT_DIR/has_match.sh
-RUSTFIX=('-execdir' "$HAS_MATCH" 'n' '//@[[:space:]]*run-rustfix'                                  '{}' ';')
-RUNPASS=('-execdir' "$HAS_MATCH" 'y' '//@[[:space:]]*run-pass'                                     '{}' ';')
-HASMAIN=('-execdir' "$HAS_MATCH" 'y' 'fn main[[:space:]]*([[:space:]]*)'                           '{}' ';')
-EMPMAIN=('-execdir' "$HAS_MATCH" 'n' 'fn main[[:space:]]*([[:space:]]*)[[:space:]]*{[[:space:]]*}' '{}' ';')
+RUSTFIX=('-execdir' "$HAS_MATCH" 'n' '//@[[:space:]]*run-rustfix'                                                  '{}' ';')
+RUNPASS=('-execdir' "$HAS_MATCH" 'y' '//@[[:space:]]*run-pass'                                                     '{}' ';')
+HASMAIN=('-execdir' "$HAS_MATCH" 'y' 'fn[[:space:]]\{1,\}main[[:space:]]*([[:space:]]*)'                           '{}' ';')
+EMPMAIN=('-execdir' "$HAS_MATCH" 'n' 'fn[[:space:]]\{1,\}main[[:space:]]*([[:space:]]*)[[:space:]]*{[[:space:]]*}' '{}' ';')
 
 # parse opts
 while getopts 'xfet' opt; do

--- a/collect_tests.sh
+++ b/collect_tests.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+die() { echo "$1"; exit 1; }
+
+# setup time mir filter
+# NOTE: temp file is needed because rustc chokes when writing directly to /dev/null
+# NOTE: this filter does not work natively on mac due to no timeout command
+TMPMIR=$PWD/temp.mir
+RUSTOPT=('-C' 'overflow-checks=off')
+TIMEMIR=('-execdir' 'timeout' '30s' 'rustc' "${RUSTOPT[@]}" '--emit' 'mir' '-o' "$TMPMIR"      '{}' ';')
+
+# setup grep filters
+RUSTFIX=('-execdir' 'grep' '-qv' '//@[[:space:]]*run-rustfix'                                  '{}' ';')
+RUNPASS=('-execdir' 'grep' '-q'  '//@[[:space:]]*run-pass'                                     '{}' ';')
+HASMAIN=('-execdir' 'grep' '-q'  'fn main[[:space:]]*([[:space:]]*)'                           '{}' ';')
+EMPMAIN=('-execdir' 'grep' '-qv' 'fn main[[:space:]]*([[:space:]]*)[[:space:]]*{[[:space:]]*}' '{}' ';')
+
+print_usage() {
+  printf "usage: $(basename $0) [-x] [-e] [-f] [-t] [-h]\n\n"
+  printf "print out rustc UI tests which satisfy certain criteria; by default those that are:\n"
+  printf "normal, passing, contain a non-empty main function, and compile in reasonable time\n\n"
+  printf "options:\n"
+  printf "x\tinclude fixed tests [may contain run-rustfix header]\n"
+  printf "e\tinclude tests with empty/missing main function\n"
+  printf "f\tinclude failing tests [may NOT contain run-pass header] (implies -t)\n"
+  printf "t\tinclude tests that fail to generate MIR within 30s\n"
+  printf "h\tprint this usage and exit\n\n"
+  printf "environment variable RUST_TOP must point to a valid rustc distribution\n"
+  exit 1
+}
+
+[ $# -eq 0 ] && print_usage
+
+[ -z "${RUST_TOP}" ] && die "Must set RUST_TOP environment variable to your local Rust compiler source directory before running this script"
+RUST_TESTS=${RUST_TOP}/tests
+[ ! -d "${RUST_TESTS}" ] && die "RUST_TOP environment variable does not appear to point to a local Rust compiler source directory"
+
+while getopts 'xfet' opt; do
+  case "${opt}" in
+    x)   RUSTFIX=()  ;;
+    e)   HASMAIN=()
+         EMPMAIN=()  ;;
+    f)   RUNPASS=()
+         TIMEMIR=()  ;;
+    t)   TIMEMIR=()  ;;
+    ?|h) print_usage ;;
+  esac
+done
+
+# find files that pass filters
+find "${RUST_TESTS}/ui"
+     -name '*.rs'    \
+     "${RUSTFIX[@]}" \
+     "${RUNPASS[@]}" \
+     "${HASMAIN[@]}" \
+     "${EMPMAIN[@]}" \
+     "${TIMEMIR[@]}" \
+     -print          \
+  | sort
+
+# remove temp mir file whenever timing mir, ignore errors
+if [ -n "${TIMEMIR[*]}" ]; then
+  rm "$TMPMIR" &> /dev/null
+fi

--- a/collect_tests.sh
+++ b/collect_tests.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
 
 set -e
-die() { echo "$1"; exit 1; }
+print_usage() {
+  printf "usage: $(basename $0) [-x] [-e] [-f] [-t] [-h]\n\n"
+  printf "print out rustc UI tests which satisfy certain criteria; by default those that are:\n"
+  printf "normal, passing, contain a non-empty main function, and compile in reasonable time\n\n"
+  printf "options:\n"
+  printf "x\tinclude fixed tests [may contain run-rustfix header]\n"
+  printf "e\tinclude tests with empty/missing main function\n"
+  printf "f\tinclude failing tests [may NOT contain run-pass header] (implies -t)\n"
+  printf "t\tinclude tests that fail to generate MIR within 30s\n"
+  printf "h\tprint this usage and exit\n\n"
+  echo "$@"
+  exit 1
+}
 
 # setup time mir filter
 # NOTE: temp file is needed because rustc chokes when writing directly to /dev/null
@@ -16,26 +28,7 @@ RUNPASS=('-execdir' 'grep' '-q'  '//@[[:space:]]*run-pass'                      
 HASMAIN=('-execdir' 'grep' '-q'  'fn main[[:space:]]*([[:space:]]*)'                           '{}' ';')
 EMPMAIN=('-execdir' 'grep' '-qv' 'fn main[[:space:]]*([[:space:]]*)[[:space:]]*{[[:space:]]*}' '{}' ';')
 
-print_usage() {
-  printf "usage: $(basename $0) [-x] [-e] [-f] [-t] [-h]\n\n"
-  printf "print out rustc UI tests which satisfy certain criteria; by default those that are:\n"
-  printf "normal, passing, contain a non-empty main function, and compile in reasonable time\n\n"
-  printf "options:\n"
-  printf "x\tinclude fixed tests [may contain run-rustfix header]\n"
-  printf "e\tinclude tests with empty/missing main function\n"
-  printf "f\tinclude failing tests [may NOT contain run-pass header] (implies -t)\n"
-  printf "t\tinclude tests that fail to generate MIR within 30s\n"
-  printf "h\tprint this usage and exit\n\n"
-  printf "environment variable RUST_TOP must point to a valid rustc distribution\n"
-  exit 1
-}
-
-[ $# -eq 0 ] && print_usage
-
-[ -z "${RUST_TOP}" ] && die "Must set RUST_TOP environment variable to your local Rust compiler source directory before running this script"
-RUST_TESTS=${RUST_TOP}/tests
-[ ! -d "${RUST_TESTS}" ] && die "RUST_TOP environment variable does not appear to point to a local Rust compiler source directory"
-
+# parse opts
 while getopts 'xfet' opt; do
   case "${opt}" in
     x)   RUSTFIX=()  ;;
@@ -44,11 +37,16 @@ while getopts 'xfet' opt; do
     f)   RUNPASS=()
          TIMEMIR=()  ;;
     t)   TIMEMIR=()  ;;
-    ?|h) print_usage ;;
+    ?|h) print_usage "environment variable RUST_TOP must point to a valid rustc distribution" ;;
   esac
 done
 
-# find files that pass filters
+# check test dir
+[ -z "${RUST_TOP}" ] && print_usage "set RUST_TOP environment variable to your local Rust compiler source directory before running this script"
+RUST_TESTS=${RUST_TOP}/tests
+[ ! -d "${RUST_TESTS}" ] && print_usage "RUST_TOP environment variable does not appear to point to a local Rust compiler source directory"
+
+# find test files that pass filters
 find "${RUST_TESTS}/ui"
      -name '*.rs'    \
      "${RUSTFIX[@]}" \

--- a/has_match.sh
+++ b/has_match.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+USAGE="usage: $0 y|n <pat> <file>\n\nalias for: grep -l|-L <pat> <file> &>/dev/null\n\nwhere return code is inverted when -L is passed\n"
+[ $# -lt 3 ] && printf "$USAGE" && exit 3
+flag=$1
+pat=$2
+file=$3
+invert=false
+case "$flag" in
+  y) flag=-l ;;
+  n) flag=-L; invert=true ;;
+  *) exit 3 ;;
+esac
+grep "$flag" "$pat" "$file" &>/dev/null
+ret=$?
+$invert && [ $ret -le 1 ] && exit $(( 1 - $ret ))
+exit $ret

--- a/rustc_mir.sh
+++ b/rustc_mir.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -eu # fail on non-zero retcode or undefined variable
+if [ $# -lt 2 ]; then
+  printf "usage $0: <inputfile> <outputfile> [extra_rustc_opt...]\n\n"
+  printf "alias for:\n\nrustc --emit mir -o <outputfile> [rustc_opt...] [extra_rustc_opt...] -- <inputfile>\n\n"
+  printf "where:\n\n[rustc_opt...] is from <inputfile> comments of form: '//@ compile-flags: [rustc_opt...]'\n"
+  exit 1
+fi
+
+# grab primary arguments and extra options
+infile=$1
+outfile=$2
+shift 2
+extraopts=("$@")
+
+# extract options embedded in input file as follows:
+# 1. ignoring return codes:
+#    - use `grep -s`  to extract 0+ lines with comment //@ compile-flags: ...
+#    - use `grep -os` to extract fragment of comment starting from colon (:)
+# 2. use `${varname:1}` to trim first character from string, i.e., the colon (:)
+# 3. use `read -a <varname> <<< "word"` to perform word splitting and store words in array variable
+set +e
+fileopts=$(grep -s '^[[:space:]]*//@[[:space:]]*compile-flags:.*$' "$infile" | grep -os ':.*$')
+set -e
+fileopts=${fileopts:1}
+read -a fileopts <<< "$fileopts"
+
+# invoke rustc with options
+echo rustc --emit mir -o "$outfile" "${fileopts[@]}" "${extraopts[@]}" -- "$infile"

--- a/rustc_mir.sh
+++ b/rustc_mir.sh
@@ -4,7 +4,9 @@ if [ $# -lt 2 ]; then
   printf "usage $0: <inputfile> <outputfile> [extra_rustc_opt...]\n\n"
   printf "alias for:\n\nrustc --emit mir -o <outputfile> [rustc_opt...] [extra_rustc_opt...] -- <inputfile>\n\n"
   printf "where:\n\n[rustc_opt...] is from <inputfile> comments of form: '//@ compile-flags: [rustc_opt...]'\n\n"
-  printf "set environment variable RUSTC_MIR_VERBOSE to see raw rustc invocation and CLI output\n"
+  printf "set environment variables:\n"
+  printf "  RUSTC_MIR_VERBOSE    - to see raw rustc invocation and output\n"
+  printf "  RUSTC_MIR_NOFILEOPTS - to ignore //@ compile-flags: ...\n"
   exit 1
 fi
 
@@ -14,17 +16,20 @@ outfile=$2
 shift 2
 extraopts=("$@")
 
-# extract options embedded in input file as follows:
+# if RUSTC_MIR_NOFILEOPTS unset, extract options embedded in input file as follows:
 # 1. ignoring return codes:
 #    - use `grep -s`  to extract 0+ lines with comment //@ compile-flags: ...
 #    - use `grep -os` to extract fragment of comment starting from colon (:)
 # 2. use `${varname:1}` to trim first character from string, i.e., the colon (:)
 # 3. use `read -a <varname> <<< "word"` to perform word splitting and store words in array variable
-set +e
-fileopts=$(grep -s '^[[:space:]]*//@[[:space:]]*compile-flags:.*$' "$infile" | grep -os ':.*$')
-set -e
-fileopts=${fileopts:1}
-read -a fileopts <<< "$fileopts"
+fileopts=()
+if [ -z "${RUSTC_MIR_NOFILEOPTS+x}" ]; then
+  set +e
+  fileopts=$(grep -s '^[[:space:]]*//@[[:space:]]*compile-flags:.*$' "$infile" | grep -os ':.*$')
+  set -e
+  fileopts=${fileopts:1}
+  read -a fileopts <<< "$fileopts"
+fi
 
 # invoke rustc with options and optionally ignore output
 rustc_cmd=(rustc --emit mir -o "$outfile" "${fileopts[@]}" "${extraopts[@]}" -- "$infile")

--- a/rustc_mir.sh
+++ b/rustc_mir.sh
@@ -3,7 +3,8 @@ set -eu # fail on non-zero retcode or undefined variable
 if [ $# -lt 2 ]; then
   printf "usage $0: <inputfile> <outputfile> [extra_rustc_opt...]\n\n"
   printf "alias for:\n\nrustc --emit mir -o <outputfile> [rustc_opt...] [extra_rustc_opt...] -- <inputfile>\n\n"
-  printf "where:\n\n[rustc_opt...] is from <inputfile> comments of form: '//@ compile-flags: [rustc_opt...]'\n"
+  printf "where:\n\n[rustc_opt...] is from <inputfile> comments of form: '//@ compile-flags: [rustc_opt...]'\n\n"
+  printf "set environment variable RUSTC_MIR_VERBOSE to see raw rustc invocation and CLI output\n"
   exit 1
 fi
 
@@ -25,5 +26,11 @@ set -e
 fileopts=${fileopts:1}
 read -a fileopts <<< "$fileopts"
 
-# invoke rustc with options
-echo rustc --emit mir -o "$outfile" "${fileopts[@]}" "${extraopts[@]}" -- "$infile"
+# invoke rustc with options and optionally ignore output
+rustc_cmd=(rustc --emit mir -o "$outfile" "${fileopts[@]}" "${extraopts[@]}" -- "$infile")
+if [ -n "${RUSTC_MIR_VERBOSE:-}" ]; then
+  printf "%s\n" "${rustc_cmd[*]}"
+  "${rustc_cmd[@]}"
+else
+  "${rustc_cmd[@]}" &>/dev/null
+fi


### PR DESCRIPTION
This PR adds a script `collect_test_sources.sh` that attempts to extract the functionality for filtering/printing `tests/ui/**/.rs` sources from the `generate_tests.sh` script. Hopefully, this will enable other tools to more easily consume the Rust source list for further processing (e.g. testing the pretty printer).

Along the way, two helper scripts were developed:

1. `rustc_mir.sh` - invokes `rustc` and optionally passes any embedded `//@ compile-flags: ...`
2. `has_match.sh` - invokes `grep -l|-L ... &>/dev/null` and flips the return code when `-L` is passed

The `rustc_mir.sh` hopefully will enable us to process a larger set of rust tests --- though it is uncertain if tests with special compilation flags will be interesting for our symbolic execution purposes. I included an env var `RUSTC_MIR_NOFILEOPTS` to disable this extra processing so that we could compare the different approaches.

EDIT: For reference, on my laptop, the script takes about 3.5 minutes to finish generating a list of source files with no extra options passed.